### PR TITLE
Added method to close the file descriptor.

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,9 @@ exports.initialize = function (dev) {
     spi.transfer = function (writebuf, readcount, cb) {
         _transfer(writebuf, readcount, cb);
     };
+    spi.close = function () {
+        fs.close( _fd );
+    };
     
     return spi;
 };


### PR DESCRIPTION
A quick patch to add a close method. Without this, the file descriptor can't be closed without exiting your app.
