### PR TITLE
Node 0.12.x compatibility via NAN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
+node_modules/
 build/

--- a/README.md
+++ b/README.md
@@ -66,14 +66,6 @@ Writes outbuffer, ignoring response bytes.
 Note that if there was an error opening the device, the `transfer`/`read`/`write` calls will fail each time called. I may [revise the initialize method](https://github.com/natevw/pi-spi/issues/2#issuecomment-27588982) so to allow you to handle the error better.
 
 
-
-## Compatibility Note
-
-This library is subject to change as it is intended for compatibility with `$somethingElse`.
-
-`TBD: more details when public`
-
-
 ## License
 
 Copyright © 2013, Nathan Vander Wilt.

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ Sets (or gets, if no argument provided) the bit ordering. Default is `SPI.order.
 
 Note that this is **bit** ordering, not *bytes* — byte ordering is up to your application.
 
-### spi.transfer(outbuffer, incount, cb)
+### spi.transfer(outbuffer, [incount,] cb)
 
-Transfers data for the longer of `outbuffer.length` or `incount` bytes. If successfully, the second parameter to your callback will be a buffer of length `incount`.
+Transfers data for the longer of `outbuffer.length` or `incount` bytes. If successfully, the second parameter to your callback will be a buffer of length `incount` (which defaults to `outbuffer.length` if not provided).
 
 ### spi.read(incount, cb)
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -3,6 +3,7 @@
     {
       "target_name": "spi_binding",
       "sources": [ "spi_binding.cc" ],
-    }
+      "include_dirs" : ["<!(node -e \"require('nan')\")"]
+    },
   ]
 }

--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@ exports.order = {
 };
 
 exports.initialize = function (dev) {
-    
     var spi = {},
         _fd = fs.openSync(dev, 'r+'),
         _speed = 4e6,
@@ -21,15 +20,18 @@ exports.initialize = function (dev) {
     
     spi.clockSpeed = function (speed) {
         if (arguments.length < 1) return _speed;
-        else _speed = speed;
+        else if (typeof speed === 'number') _speed = speed;
+        else throw TypeError("Clock speed must be a number.");
     };
     spi.dataMode = function (mode) {
         if (arguments.length < 1) return _mode;
-        else _mode = mode;
+        else if (typeof mode === 'number') _mode = mode;
+        else throw TypeError("Data mode should be CPHA or CPOL.");
     };
     spi.bitOrder = function (order) {
         if (arguments.length < 1) return _order;
-        else _order = order;
+        else if (typeof order === 'number') _order = order;
+        else throw TypeError("Bit order should be MSB_FIRST or LSB_FIRST.");
     };
     
     
@@ -38,16 +40,23 @@ exports.initialize = function (dev) {
     }
     
     spi.write = function (writebuf, cb) {
+        if (!Buffer.isBuffer(writebuf)) throw TypeError("Write data is not a buffer");
+        if (typeof cb !== 'function') throw TypeError("Callback not provided");
         _transfer(writebuf, 0, cb);
     };
     spi.read = function (readcount, cb) {
+        if (typeof readcount !== 'number') throw TypeError("Read count is not a number");
+        if (typeof cb !== 'function') throw TypeError("Callback not provided");
         _transfer(null, readcount, cb);
     };
     spi.transfer = function (writebuf, readcount, cb) {
+        if (!Buffer.isBuffer(writebuf)) throw TypeError("Write data is not a buffer");
+        if (typeof readcount !== 'number') throw TypeError("Read count is not a number");
+        if (typeof cb !== 'function') throw TypeError("Callback not provided");
         _transfer(writebuf, readcount, cb);
     };
     spi.close = function () {
-        fs.close( _fd );
+        fs.close(_fd);
     };
     
     return spi;

--- a/index.js
+++ b/index.js
@@ -51,7 +51,10 @@ exports.initialize = function (dev) {
     };
     spi.transfer = function (writebuf, readcount, cb) {
         if (!Buffer.isBuffer(writebuf)) throw TypeError("Write data is not a buffer");
-        if (typeof readcount !== 'number') throw TypeError("Read count is not a number");
+        if (typeof readcount === 'function') {
+            cb = readcount;
+            readcount = writebuf.length;
+        } else if (typeof readcount !== 'number') throw TypeError("Read count is not a number");
         if (typeof cb !== 'function') throw TypeError("Callback not provided");
         _transfer(writebuf, readcount, cb);
     };

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
   "license": "BSD-2-Clause",
   "bugs": {
     "url": "https://github.com/natevw/pi-spi/issues"
+  },
+  "dependencies": {
+    "nan": "^1.6.2"
   }
 }

--- a/spi_binding.cc
+++ b/spi_binding.cc
@@ -6,6 +6,10 @@
 #include <cstring>
 #include <cerrno>
 
+#ifdef WIN32      // this substitution should work since we're not using return value…
+#define snprintf(a,b,...) _snprintf_s(a,b,_TRUNCATE,__VA_ARGS__)
+#endif
+
 #if __linux__
 #include <sys/ioctl.h>
 #include <linux/spi/spidev.h>

--- a/spi_binding.cc
+++ b/spi_binding.cc
@@ -1,6 +1,5 @@
 #include <node.h>
-#include <node_version.h>
-#include <node_buffer.h>
+#include <nan.h>
 
 #include <cstdlib>
 #include <cstdio>
@@ -17,115 +16,123 @@ using namespace v8;
 
 uv_mutex_t spiAccess;
 
-
-// HT http://kkaefer.github.io/node-cpp-modules/#calling-async
-struct Baton {
-    uv_work_t request;
-    Persistent<Function> callback;
-    int err;
+class SpiTransfer : public NanAsyncWorker {
+  public:
+      SpiTransfer(NanCallback *cb, int fd, uint32_t speed, uint8_t mode, uint8_t order, v8::Handle<v8::Value> _writebuf, size_t readcount) :
+        NanAsyncWorker(cb), fd(fd), speed(speed), mode(mode), order(order), readcount(readcount)
+      {
+          size_t writelen;
+          char* writedata;
+          if (_writebuf->IsObject()) {
+              Local<Object> writebuf = _writebuf->ToObject();
+              writelen = node::Buffer::Length(writebuf);
+              assert(writelen <= 0xffffffff /*std::numeric_limits<T>::max()*/);
+              writedata = node::Buffer::Data(writebuf);
+          } else {
+              writelen = 0;
+              writedata = NULL;
+          }
+          
+          buflen = (readcount > writelen) ? readcount : writelen /* std::max(readcount,writelen) */;
+          buffer = (uint8_t*)malloc(buflen);
+          if (writelen) memcpy(buffer, writedata, writelen);
+          if (readcount > writelen) memset(buffer+writelen, 0, readcount-writelen);
+          
+          //printf("fd: %i, speed: %u, mode: %i, order: %i\n", fd, speed, mode, order);
+          //printf("writelen: %u, readcount: %u, buflen=%u\n", (uint32_t)writelen, readcount, buflen);
+      }
+      ~SpiTransfer() {}
+      
+      void Execute () {
+          // see https://raw.github.com/torvalds/linux/master/Documentation/spi/spidev_test.c
+          // http://lxr.free-electrons.com/source/include/uapi/linux/spi/spidev.h#L53
+          // https://www.kernel.org/doc/Documentation/spi/spidev
+          int ret = 0;
+      #ifdef SPI_IOC_MESSAGE
+          uv_mutex_lock(&spiAccess);
+          ret = ioctl(fd, SPI_IOC_WR_MODE, &mode);
+          if (ret != -1) {
+              ret = ioctl(fd, SPI_IOC_WR_LSB_FIRST, &order);
+              if (ret != -1) {
+                  struct spi_ioc_transfer msg = {
+                      /*.tx_buf = */ (uintptr_t)buffer,
+                      /*.rx_buf = */ (uintptr_t)buffer,
+                      /*.len = */ buflen,
+                      /*.speed_hz = */ speed,
+                      
+                      // avoid "missing initializer" warnings…
+                      /*.delay_usecs = */ 0,
+                      /*.bits_per_word = */ 0,
+                      /*.cs_change = */ 0,
+                      /*.pad = */ 0,
+                  };
+                  ret = ioctl(fd, SPI_IOC_MESSAGE(1), &msg);
+              }
+          }
+          uv_mutex_unlock(&spiAccess);
+      #else
+      #warning "Building without SPI support"
+          (void)fd;
+          (void)speed;
+          (void)mode;
+          (void)order;
+          (void)readcount;
+          (void)buflen;
+          (void)buffer;
+          ret = -1;
+          errno = ENOSYS;
+      #endif
+          err = (ret == -1) ? errno : 0;
+    }
+      
+    void HandleOKCallback () {
+        NanScope();
+        
+        Local<Value> e;
+        if (err) {
+            char* msg;
+            asprintf(&msg, "SPI error: %s (errno %i)", strerror(err), err);
+            e = NanError(msg);
+            free(msg);
+        } else {
+            e = NanNull();
+        }
+        
+        Local<Value> d;
+        if (!err && readcount) {
+            d = NanNewBufferHandle((const char*)buffer, readcount);
+        } else {
+            d = NanNull();
+        }
+        
+        TryCatch try_catch;
+        if (0 && err) {
+            Local<Value> v[] = {e};
+            callback->Call(1, v);
+        } else {
+            Local<Value> v[] = {e,d};
+            callback->Call(2, v);
+        }
+        
+        if (try_catch.HasCaught()) {
+            node::FatalException(try_catch);
+        }
+    };
     
+  private:
     int fd;
     uint32_t speed;
     uint8_t mode;
     uint8_t order;
     uint32_t readcount;
-    uint32_t buflen;
-    uint8_t buffer[0];      // allocated larger
+    size_t buflen;
+    uint8_t* buffer;
+    
+    int err;
 };
 
-void _Transfer(uv_work_t* req) {
-    Baton* baton = static_cast<Baton*>(req->data);
-    
-    // see https://raw.github.com/torvalds/linux/master/Documentation/spi/spidev_test.c
-    // http://lxr.free-electrons.com/source/include/uapi/linux/spi/spidev.h#L53
-    // https://www.kernel.org/doc/Documentation/spi/spidev
-    int ret = 0;
-#ifdef SPI_IOC_MESSAGE
-    uv_mutex_lock(&spiAccess);
-    ret = ioctl(baton->fd, SPI_IOC_WR_MODE, &baton->mode);
-    if (ret != -1) {
-        ret = ioctl(baton->fd, SPI_IOC_WR_LSB_FIRST, &baton->order);
-        if (ret != -1) {
-            struct spi_ioc_transfer msg = {
-                /*.tx_buf = */ (uintptr_t)baton->buffer,
-                /*.rx_buf = */ (uintptr_t)baton->buffer,
-                /*.len = */ baton->buflen,
-                /*.speed_hz = */ baton->speed,
-                
-                // avoid "missing initializer" warnings…
-                /*.delay_usecs = */ 0,
-                /*.bits_per_word = */ 0,
-                /*.cs_change = */ 0,
-                /*.pad = */ 0,
-            };
-            ret = ioctl(baton->fd, SPI_IOC_MESSAGE(1), &msg);
-        }
-    }
-    uv_mutex_unlock(&spiAccess);
-#else
-#warning "Building without SPI support"
-    ret = -1;
-    errno = ENOSYS;
-#endif
-    baton->err = (ret == -1) ? errno : 0;
-}
-
-void Finish_Transfer(uv_work_t* req, int status) {
-    (void)status;           // AFAICT, only used w/uv_cancel
-    HandleScope scope;
-    Baton* baton = static_cast<Baton*>(req->data);
-    
-    Local<Value> e;
-    if (baton->err) {
-        char* msg;
-        asprintf(&msg, "SPI error: %s (errno %i)", strerror(baton->err), baton->err);
-        e = Exception::Error(String::New(msg));
-        free(msg);
-    } else {
-        e = Local<Value>::New(Null());
-    }
-    
-    Local<Value> d;
-    if (!baton->err && baton->readcount) {
-        // via http://deadhorse.me/nodejs/2012/10/10/c_addon_in_nodejs_buffer.html
-        // and http://www.samcday.com.au/blog/2011/03/03/creating-a-proper-buffer-in-a-node-c-addon/
-        node::Buffer* b = node::Buffer::New((char*)baton->buffer, baton->readcount);        // in node 0.10.x this is a SlowBuffer
-        Local<Object> globalObj = Context::GetCurrent()->Global();
-        Local<Function> bufferConstructor = Local<Function>::Cast(globalObj->Get(String::New("Buffer")));       // …which we wrap.
-        // TODO: it looks like handle_ might go away soon.
-        // c.f. https://groups.google.com/d/msg/nodejs/GmHqobrM_TA/SaaP3oHVFCoJ for lead on this and other 0.11.x changes
-        Handle<Value> v[] = {b->handle_, Integer::New(baton->readcount), Integer::New(0)};
-        d = bufferConstructor->NewInstance(3, v);
-    } else {
-        d = Local<Value>::New(Null());
-    }
-    
-    TryCatch try_catch;
-    if (0 && baton->err) {
-        Local<Value> v[] = {e};
-        baton->callback->Call(Context::GetCurrent()->Global(), 1, v);
-    } else {
-        Local<Value> v[] = {e,d};
-        baton->callback->Call(Context::GetCurrent()->Global(), 2, v);
-    }
-    baton->callback.Dispose();
-    delete[] baton;
-    
-    if (try_catch.HasCaught()) {
-        node::FatalException(try_catch);
-    }
-}
-
-
-
-Handle<Value> Transfer(const Arguments& args) {
-#if NODE_VERSION_AT_LEAST(0, 11, 0)
-    Isolate* isolate = Isolate::GetCurrent();
-    HandleScope scope(isolate);
-#else
-#define isolate
-    HandleScope scope;
-#endif
+NAN_METHOD(Transfer) {
+    NanScope();
     
     // (fd, speed, mode, order, writebuf, readcount, cb)
     assert(args.Length() == 7);
@@ -137,47 +144,24 @@ Handle<Value> Transfer(const Arguments& args) {
     assert(args[5]->IsNumber());
     assert(args[6]->IsFunction());
     
-    uint32_t readcount = args[5]->ToUint32()->Value();
+    int fd = args[0]->Int32Value();
+    uint32_t speed = args[1]->Uint32Value();
+    uint8_t mode = args[2]->Uint32Value();
+    uint8_t order = args[3]->Uint32Value();
+    v8::Handle<v8::Value> writebuf = args[4];
+    size_t readcount = args[5]->Uint32Value();
+    NanCallback* cb = new NanCallback(args[6].As<Function>());
     
-    size_t writelen;
-    char* writedata;
-    if (args[4]->IsObject()) {
-        Local<Object> writebuf = args[4]->ToObject();
-        writelen = node::Buffer::Length(writebuf);
-        assert(writelen <= 0xffffffff /*std::numeric_limits<T>::max()*/);
-        writedata = node::Buffer::Data(writebuf);
-    } else {
-        writelen = 0;
-        writedata = NULL;
-    }
-    
-    uint32_t buflen = (readcount > writelen) ? readcount : writelen /* std::max(readcount,writelen) */;
-    
-    Baton* baton = (Baton*)new uint8_t[sizeof(Baton)+buflen];
-    baton->request.data = baton;
-    baton->callback = Persistent<Function>::New(Local<Function>::Cast(args[6]));
-    baton->fd = args[0]->ToInt32()->Value();
-    baton->speed = args[1]->ToUint32()->Value();
-    baton->mode = args[2]->ToUint32()->Value();
-    baton->order = args[3]->ToUint32()->Value();
-    baton->readcount = readcount;
-    baton->buflen = buflen;
-    if (writelen) memcpy(baton->buffer, writedata, writelen);
-    if (readcount > writelen) memset(baton->buffer+writelen, 0, readcount-writelen);
-    //printf("fd: %i, speed: %u, mode: %i, order: %i\n", baton->fd, baton->speed, baton->mode, baton->order);
-    //printf("writelen: %u, readcount: %u, buflen=%u\n", (uint32_t)writelen, readcount, buflen);
-    
-    uv_queue_work(uv_default_loop(), &baton->request, _Transfer, Finish_Transfer);
-    
-    return scope.Close(Undefined(isolate));
+    NanAsyncQueueWorker(new SpiTransfer(cb, fd, speed, mode, order, writebuf, readcount));
+    NanReturnUndefined();
 }
 
-void init(Handle<Object> exports) {
+void InitAll(Handle<Object> exports) {
     uv_mutex_init(&spiAccess);      // no matching `uv_mutex_destroy` but there's no module deinit…
     exports->Set(
-        String::NewSymbol("transfer"),
-        FunctionTemplate::New(Transfer)->GetFunction()
+        NanNew<String>("transfer"),
+        NanNew<FunctionTemplate>(Transfer)->GetFunction()
     );
 }
 
-NODE_MODULE(spi_binding, init)
+NODE_MODULE(spi_binding, InitAll)

--- a/spi_binding.cc
+++ b/spi_binding.cc
@@ -71,7 +71,11 @@ class SpiTransfer : public NanAsyncWorker {
           }
           uv_mutex_unlock(&spiAccess);
       #else
-      #warning "Building without SPI support"
+        #ifdef __GNUC__
+          #warning "Building without SPI support"
+        #else
+          #pragma message "Building without SPI support"
+        #endif
           (void)fd;
           (void)speed;
           (void)mode;

--- a/spi_binding.cc
+++ b/spi_binding.cc
@@ -94,10 +94,9 @@ class SpiTransfer : public NanAsyncWorker {
         
         Local<Value> e;
         if (err) {
-            char* msg;
-            asprintf(&msg, "SPI error: %s (errno %i)", strerror(err), err);
+            char msg[1024];
+            snprintf(msg, sizeof(msg), "SPI error: %s (errno %i)", strerror(err), err);
             e = NanError(msg);
-            free(msg);
         } else {
             e = NanNull();
         }

--- a/spi_binding.cc
+++ b/spi_binding.cc
@@ -74,7 +74,7 @@ class SpiTransfer : public NanAsyncWorker {
         #ifdef __GNUC__
           #warning "Building without SPI support"
         #else
-          #pragma message "Building without SPI support"
+          #pragma message("Building without SPI support")
         #endif
           (void)fd;
           (void)speed;

--- a/stub-test.js
+++ b/stub-test.js
@@ -1,0 +1,5 @@
+// this one is intended for testing stub binding on platforms where not actually implemented
+var stubDevice = (process.platform === 'win32') ? "\\\\.\\NUL" : "/dev/null";
+require("./").initialize(stubDevice).transfer(Buffer("-"), function (e,d) {
+    console.log(e,d);
+});


### PR DESCRIPTION
I've rewritten the native bindings to use https://github.com/rvagg/nan which now lets it compile on both 0.10 (and perhaps earlier) and 0.12 (and perhaps forks…).

This also adds a bit of polish to arguments handling, with JS-level type checking and a default value for readcount on `spi.transfer`.

This should fix https://github.com/natevw/pi-spi/issues/14 and https://github.com/natevw/pi-spi/issues/8