### PR TITLE
Avoid missing initialiser warning on linux 3.15+

### DIFF
--- a/spi_binding.cc
+++ b/spi_binding.cc
@@ -68,6 +68,8 @@ class SpiTransfer : public Nan::AsyncWorker {
                       /*.delay_usecs = */ 0,
                       /*.bits_per_word = */ 0,
                       /*.cs_change = */ 0,
+                      /*.tx_nbits = */ 0,
+                      /*.rx_nbits = */ 0, 
                       /*.pad = */ 0,
                   };
                   ret = ioctl(fd, SPI_IOC_MESSAGE(1), &msg);


### PR DESCRIPTION
spi_ioc_transfer struct since 3.15 has included two more entries
http://lxr.free-electrons.com/source/include/uapi/linux/spi/spidev.h?v=3.15
