### PR TITLE
fix memory leak when no rx.

### DIFF
--- a/spi_binding.cc
+++ b/spi_binding.cc
@@ -102,6 +102,7 @@ class SpiTransfer : public Nan::AsyncWorker {
         if (!err && readcount) {
             d = Nan::NewBuffer((char*)buffer, readcount).ToLocalChecked();
         } else {
+            free(buffer);
             d = Nan::Null();
         }
         


### PR DESCRIPTION
You forget free allocated buffer when no response expected for SPI, leaking memory.