### PR TITLE
adding callback to spi.close

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,8 +58,8 @@ exports.initialize = function (dev) {
         if (typeof cb !== 'function') throw TypeError("Callback not provided");
         _transfer(writebuf, readcount, cb);
     };
-    spi.close = function () {
-        fs.close(_fd);
+    spi.close = function (cb) {
+        fs.close(_fd, cb);
     };
     
     return spi;


### PR DESCRIPTION
Hi there, it's me again.

I found a little "error" where the `fs.close` function needs a callback and if this callback is not provided the code throws an error when calling `SPI.close`.
I don't know if it is even necessary to call that, but safe is safe 😄

If the callback is not provided the same error is thrown, so existing implementations should not be affected.